### PR TITLE
set netconf_version and capabilities manually

### DIFF
--- a/scrapli_netconf/channel/async_channel.py
+++ b/scrapli_netconf/channel/async_channel.py
@@ -6,7 +6,7 @@ from scrapli.channel.base_channel import BaseChannelArgs
 from scrapli.decorators import ChannelTimeout
 from scrapli.transport.base.async_transport import AsyncTransport
 from scrapli_netconf.channel.base_channel import BaseNetconfChannel, NetconfBaseChannelArgs
-from scrapli_netconf.constants import NetconfVersion
+from scrapli_netconf.constants import NetconfClientCapabilities, NetconfVersion
 
 
 class AsyncNetconfChannel(AsyncChannel, BaseNetconfChannel):
@@ -39,9 +39,17 @@ class AsyncNetconfChannel(AsyncChannel, BaseNetconfChannel):
             N/A
 
         """
-        raw_server_capabilities = await self._get_server_capabilities()
-
-        self._process_capabilities_exchange(raw_server_capabilities=raw_server_capabilities)
+        raw_server_capabilities = self._get_server_capabilities()
+        if self._netconf_base_channel_args.netconf_version == NetconfVersion.VERSION_1_0:
+            self._netconf_base_channel_args.client_capabilities = (
+                NetconfClientCapabilities.CAPABILITIES_1_0
+            )
+        elif self._netconf_base_channel_args.netconf_version == NetconfVersion.VERSION_1_1:
+            self._netconf_base_channel_args.client_capabilities = (
+                NetconfClientCapabilities.CAPABILITIES_1_1
+            )
+        else:
+            self._process_capabilities_exchange(raw_server_capabilities=raw_server_capabilities)
 
         await self._check_echo()
         await self._send_client_capabilities()

--- a/scrapli_netconf/channel/sync_channel.py
+++ b/scrapli_netconf/channel/sync_channel.py
@@ -11,7 +11,7 @@ from scrapli.decorators import ChannelTimeout
 from scrapli.exceptions import ScrapliAuthenticationFailed
 from scrapli.transport.base import Transport
 from scrapli_netconf.channel.base_channel import BaseNetconfChannel, NetconfBaseChannelArgs
-from scrapli_netconf.constants import NetconfVersion
+from scrapli_netconf.constants import NetconfVersion, NetconfClientCapabilities
 from scrapli_netconf.transport.plugins.system.transport import NetconfSystemTransport
 
 HELLO_MATCH = re.compile(pattern=rb"<(\w+\:){0,1}hello", flags=re.I)
@@ -48,8 +48,12 @@ class NetconfChannel(Channel, BaseNetconfChannel):
 
         """
         raw_server_capabilities = self._get_server_capabilities()
-
-        self._process_capabilities_exchange(raw_server_capabilities=raw_server_capabilities)
+        if self._netconf_base_channel_args.netconf_version == NetconfVersion.VERSION_1_0:
+            self._netconf_base_channel_args.client_capabilities = NetconfClientCapabilities.CAPABILITIES_1_0
+        elif self._netconf_base_channel_args.netconf_version == NetconfVersion.VERSION_1_1:
+            self._netconf_base_channel_args.client_capabilities = NetconfClientCapabilities.CAPABILITIES_1_1
+        else:
+            self._process_capabilities_exchange(raw_server_capabilities=raw_server_capabilities)
 
         self._check_echo()
         self._send_client_capabilities()

--- a/scrapli_netconf/channel/sync_channel.py
+++ b/scrapli_netconf/channel/sync_channel.py
@@ -11,7 +11,7 @@ from scrapli.decorators import ChannelTimeout
 from scrapli.exceptions import ScrapliAuthenticationFailed
 from scrapli.transport.base import Transport
 from scrapli_netconf.channel.base_channel import BaseNetconfChannel, NetconfBaseChannelArgs
-from scrapli_netconf.constants import NetconfVersion, NetconfClientCapabilities
+from scrapli_netconf.constants import NetconfClientCapabilities, NetconfVersion
 from scrapli_netconf.transport.plugins.system.transport import NetconfSystemTransport
 
 HELLO_MATCH = re.compile(pattern=rb"<(\w+\:){0,1}hello", flags=re.I)
@@ -49,9 +49,13 @@ class NetconfChannel(Channel, BaseNetconfChannel):
         """
         raw_server_capabilities = self._get_server_capabilities()
         if self._netconf_base_channel_args.netconf_version == NetconfVersion.VERSION_1_0:
-            self._netconf_base_channel_args.client_capabilities = NetconfClientCapabilities.CAPABILITIES_1_0
+            self._netconf_base_channel_args.client_capabilities = (
+                NetconfClientCapabilities.CAPABILITIES_1_0
+            )
         elif self._netconf_base_channel_args.netconf_version == NetconfVersion.VERSION_1_1:
-            self._netconf_base_channel_args.client_capabilities = NetconfClientCapabilities.CAPABILITIES_1_1
+            self._netconf_base_channel_args.client_capabilities = (
+                NetconfClientCapabilities.CAPABILITIES_1_1
+            )
         else:
             self._process_capabilities_exchange(raw_server_capabilities=raw_server_capabilities)
 


### PR DESCRIPTION
# Description

Issue #28 .  This PR allows setting netconf_version manually for situation where it is not ideal to detect the server capabilities and dynamically set client capabilities.  It preserves the dynamic detection and setting of client capabilities when a manual setting is not set.  This helps to interact with misbehaving devices that advertise Netconf 1.1 but doesn't fully support it.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested against a device that advertise Netconf 1.1 capabilities but subsequently timeout when the server capabilities are parsed dynamically.  Setting ```conn.netconf_version = NetconfVersion.VERSION_1_0``` manually prior to ```conn.open()``` allows the device to communicates succesfully.


# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
