### PR TITLE
Add option to specify with-defaults when performing get_config

### DIFF
--- a/scrapli_netconf/driver/async_driver.py
+++ b/scrapli_netconf/driver/async_driver.py
@@ -129,6 +129,7 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
         source: str = "running",
         filters: Optional[Union[str, List[str]]] = None,
         filter_type: str = "subtree",
+        default_type: Optional[str] = None,
     ) -> NetconfResponse:
         """
         Netconf get-config operation
@@ -137,6 +138,7 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
             source: configuration source to get; typically one of running|startup|candidate
             filters: string or list of strings of filters to apply to configuration
             filter_type: type of filter; subtree|xpath
+            default_type: string of with-default mode to apply when retrieving configuration
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object
@@ -145,7 +147,9 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
             N/A
 
         """
-        response = self._pre_get_config(source=source, filters=filters, filter_type=filter_type)
+        response = self._pre_get_config(
+            source=source, filters=filters, filter_type=filter_type, default_type=default_type
+        )
         raw_response = await self.channel.send_input_netconf(response.channel_input)
 
         response.record_response(raw_response)

--- a/scrapli_netconf/driver/base_driver.py
+++ b/scrapli_netconf/driver/base_driver.py
@@ -21,7 +21,10 @@ PARSER = etree.XMLParser(remove_blank_text=True, recover=True)
 class NetconfBaseOperations(Enum):
     FILTER_SUBTREE = "<filter type='{filter_type}'></filter>"
     FILTER_XPATH = "<filter type='{filter_type}' select='{xpath}'></filter>"
-    WITH_DEFAULTS_SUBTREE = '<with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">{default_type}</with-defaults>'  # noqa: E501
+    WITH_DEFAULTS_SUBTREE = (
+        "<with-defaults xmlns='urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults'>"
+        "{default_type}</with-defaults>"
+    )
     GET = "<get></get>"
     GET_CONFIG = "<get-config><source><{source}/></source></get-config>"
     EDIT_CONFIG = "<edit-config><target><{target}/></target></edit-config>"
@@ -402,7 +405,8 @@ class NetconfBaseDriver(BaseDriver):
             )
         else:
             raise ValueError(
-                f"`default_type` should be one of report-all|trim|explicit|report-all-tagged, got `{default_type}`"  # noqa: E501
+                "`default_type` should be one of report-all|trim|explicit|report-all-tagged, "
+                f"got `{default_type}`"
             )
         return xml_with_defaults_element
 

--- a/scrapli_netconf/driver/base_driver.py
+++ b/scrapli_netconf/driver/base_driver.py
@@ -373,8 +373,7 @@ class NetconfBaseDriver(BaseDriver):
             raise ValueError(f"`filter_type` should be one of subtree|xpath, got `{filter_type}`")
         return xml_filter_elem
 
-    @staticmethod
-    def _build_with_defaults(default_type: str = "report-all") -> Element:
+    def _build_with_defaults(self, default_type: str = "report-all") -> Element:
         """
         Create with-defaults element for a given operation
 
@@ -390,6 +389,13 @@ class NetconfBaseDriver(BaseDriver):
         """
 
         if default_type in ["report-all", "trim", "explicit", "report-all-tagged"]:
+            if (
+                "urn:ietf:params:netconf:capability:with-defaults:1.0"
+                not in self.server_capabilities
+            ):
+                msg = "with-defaults requested, but is not supported by the server"
+                self.logger.exception(msg)
+                raise CapabilityNotSupported(msg)
             xml_with_defaults_element = etree.fromstring(
                 NetconfBaseOperations.WITH_DEFAULTS_SUBTREE.value.format(default_type=default_type),
                 parser=PARSER,

--- a/scrapli_netconf/driver/sync_driver.py
+++ b/scrapli_netconf/driver/sync_driver.py
@@ -139,6 +139,7 @@ class NetconfDriver(Driver, NetconfBaseDriver):
         source: str = "running",
         filters: Optional[Union[str, List[str]]] = None,
         filter_type: str = "subtree",
+        default_type: Optional[str] = None,
     ) -> NetconfResponse:
         """
         Netconf get-config operation
@@ -147,6 +148,7 @@ class NetconfDriver(Driver, NetconfBaseDriver):
             source: configuration source to get; typically one of running|startup|candidate
             filters: string or list of strings of filters to apply to configuration
             filter_type: type of filter; subtree|xpath
+            default_type: string of with-default mode to apply when retrieving configuration
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object
@@ -155,7 +157,9 @@ class NetconfDriver(Driver, NetconfBaseDriver):
             N/A
 
         """
-        response = self._pre_get_config(source=source, filters=filters, filter_type=filter_type)
+        response = self._pre_get_config(
+            source=source, filters=filters, filter_type=filter_type, default_type=default_type
+        )
         raw_response = self.channel.send_input_netconf(response.channel_input)
 
         response.record_response(raw_response)

--- a/tests/unit/driver/test_base_driver.py
+++ b/tests/unit/driver/test_base_driver.py
@@ -10,6 +10,8 @@ GET_CHANNEL_INPUT_1_0 = """<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<rpc xmln
 GET_CHANNEL_INPUT_1_1 = """<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><get><filter type="subtree"><netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg"/></filter></get></rpc>"""
 GET_CONFIG_CHANNEL_INPUT_1_0 = """<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><get-config><source><running/></source><filter type="subtree"><netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg"/></filter></get-config></rpc>\n]]>]]>"""
 GET_CONFIG_CHANNEL_INPUT_1_1 = """<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><get-config><source><running/></source><filter type="subtree"><netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg"/></filter></get-config></rpc>"""
+GET_CONFIG_WITH_DEFAULT_CHANNEL_INPUT_1_0 = """<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><get-config><source><running/></source><filter type="subtree"><netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg"/></filter><with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">report-all</with-defaults></get-config></rpc>\n]]>]]>"""
+GET_CONFIG_WITH_DEFAULT_CHANNEL_INPUT_1_1 = """<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><get-config><source><running/></source><filter type="subtree"><netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg"/></filter><with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">report-all</with-defaults></get-config></rpc>"""
 EDIT_CONFIG_CHANNEL_INPUT_1_0 = """<?xml version='1.0' encoding='utf-8'?>
 <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><edit-config><target><running/></target><config><cdp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cdp-cfg"><timer>80</timer><enable>true</enable><log-adjacency/><hold-time>200</hold-time><advertise-v1-only/></cdp></config></edit-config></rpc>
 ]]>]]>"""
@@ -155,6 +157,25 @@ def test_pre_get_config(dummy_conn, capabilities):
     expected_channel_input = capabilities[1]
     filter_ = """<netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg"></netconf-yang>"""
     response = dummy_conn._pre_get_config(filters=[filter_])
+    assert isinstance(response, NetconfResponse)
+    assert response.channel_input == expected_channel_input
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (NetconfVersion.VERSION_1_0, GET_CONFIG_WITH_DEFAULT_CHANNEL_INPUT_1_0),
+        (NetconfVersion.VERSION_1_1, GET_CONFIG_WITH_DEFAULT_CHANNEL_INPUT_1_1),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_get_config_with_default(dummy_conn, capabilities):
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.readable_datastores = ["running"]
+    expected_channel_input = capabilities[1]
+    filter_ = """<netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg"></netconf-yang>"""
+    default_type_ = "report-all"
+    response = dummy_conn._pre_get_config(filters=[filter_], default_type=default_type_)
     assert isinstance(response, NetconfResponse)
     assert response.channel_input == expected_channel_input
 

--- a/tests/unit/driver/test_base_driver.py
+++ b/tests/unit/driver/test_base_driver.py
@@ -112,6 +112,38 @@ def test_build_filters():
     pass
 
 
+def test_build_with_defaults(dummy_conn):
+    report_all_elem = dummy_conn._build_with_defaults("report-all")
+    trim_elem = dummy_conn._build_with_defaults("trim")
+    explicit_elem = dummy_conn._build_with_defaults("explicit")
+    tagged_elem = dummy_conn._build_with_defaults("report-all-tagged")
+    assert (
+        etree.tostring(report_all_elem)
+        == b"""<with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">report-all</with-defaults>"""
+    )
+    assert (
+        etree.tostring(trim_elem)
+        == b"""<with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">trim</with-defaults>"""
+    )
+    assert (
+        etree.tostring(explicit_elem)
+        == b"""<with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">explicit</with-defaults>"""
+    )
+    assert (
+        etree.tostring(tagged_elem)
+        == b"""<with-defaults xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults">report-all-tagged</with-defaults>"""
+    )
+
+
+def test_build_with_defaults_exception_invalid_type(dummy_conn):
+    with pytest.raises(ValueError) as exc:
+        dummy_conn._build_with_defaults(default_type="sushicat")
+    assert (
+        str(exc.value)
+        == "`default_type` should be one of report-all|trim|explicit|report-all-tagged, got `sushicat`"
+    )
+
+
 def test_build_filters_exception_invalid_type(dummy_conn):
     with pytest.raises(ValueError) as exc:
         dummy_conn._build_filters(filters=[], filter_type="tacocat")

--- a/tests/unit/driver/test_base_driver.py
+++ b/tests/unit/driver/test_base_driver.py
@@ -113,6 +113,7 @@ def test_build_filters():
 
 
 def test_build_with_defaults(dummy_conn):
+    dummy_conn.server_capabilities = ["urn:ietf:params:netconf:capability:with-defaults:1.0"]
     report_all_elem = dummy_conn._build_with_defaults("report-all")
     trim_elem = dummy_conn._build_with_defaults("trim")
     explicit_elem = dummy_conn._build_with_defaults("explicit")
@@ -142,6 +143,13 @@ def test_build_with_defaults_exception_invalid_type(dummy_conn):
         str(exc.value)
         == "`default_type` should be one of report-all|trim|explicit|report-all-tagged, got `sushicat`"
     )
+
+
+def test_build_with_defaults_exception_unsupported(dummy_conn):
+    dummy_conn.server_capabilities = []
+    with pytest.raises(CapabilityNotSupported) as exc:
+        dummy_conn._build_with_defaults(default_type="trim")
+    assert str(exc.value) == "with-defaults requested, but is not supported by the server"
 
 
 def test_build_filters_exception_invalid_type(dummy_conn):
@@ -202,6 +210,7 @@ def test_pre_get_config(dummy_conn, capabilities):
     ids=["1.0", "1.1"],
 )
 def test_pre_get_config_with_default(dummy_conn, capabilities):
+    dummy_conn.server_capabilities = ["urn:ietf:params:netconf:capability:with-defaults:1.0"]
     dummy_conn.netconf_version = capabilities[0]
     dummy_conn.readable_datastores = ["running"]
     expected_channel_input = capabilities[1]


### PR DESCRIPTION
# Description

Issue #29 . This PR provides the option to specify the default_type when performing a get_config per RFC 6243.  This will pulls the configuration with default settings that are typically hidden.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested against Siemens RX1511.  Also created unit tests.

# Checklist:

- [x] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [x] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [x] New and existing unit tests pass locally with my changes
