### PR TITLE
option to *not* compress channel inputs

### DIFF
--- a/scrapli_netconf/channel/base_channel.py
+++ b/scrapli_netconf/channel/base_channel.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from lxml import etree
 
 from scrapli.channel.base_channel import BaseChannel
-from scrapli_netconf.constants import NetconfClientCapabilities, NetconfVersion
+from scrapli_netconf.constants import NetconfClientCapabilities, NetconfVersion, XmlParserVersion
 from scrapli_netconf.exceptions import CapabilityNotSupported, CouldNotExchangeCapabilities
 
 
@@ -15,6 +15,7 @@ class NetconfBaseChannelArgs:
     netconf_version: NetconfVersion
     server_capabilities: Optional[List[str]] = None
     client_capabilities: NetconfClientCapabilities = NetconfClientCapabilities.UNKNOWN
+    xml_parser: XmlParserVersion = XmlParserVersion.COMPRESSED_PARSER
 
 
 class BaseNetconfChannel(BaseChannel):
@@ -32,7 +33,7 @@ class BaseNetconfChannel(BaseChannel):
 
         Raises:
             CapabilityNotSupported: if user has provided a preferred netconf version but it is not
-                available in servers offered capabilites
+                available in servers offered capabilities
 
         """
         server_capabilities = self._parse_server_capabilities(

--- a/scrapli_netconf/constants.py
+++ b/scrapli_netconf/constants.py
@@ -2,6 +2,11 @@
 from enum import Enum
 
 
+class XmlParserVersion(Enum):
+    COMPRESSED_PARSER = "flat"
+    STANDARD_PARSER = "standard"
+
+
 class NetconfVersion(Enum):
     UNKNOWN = "unknown"
     VERSION_1_0 = "1.0"

--- a/scrapli_netconf/driver/async_driver.py
+++ b/scrapli_netconf/driver/async_driver.py
@@ -38,6 +38,7 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
         channel_log: Union[str, bool] = False,
         channel_lock: bool = False,
         preferred_netconf_version: Optional[str] = None,
+        use_compressed_parser: bool = True,
     ) -> None:
         super().__init__(
             host=host,
@@ -68,9 +69,13 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
         _preferred_netconf_version = self._determine_preferred_netconf_version(
             preferred_netconf_version=preferred_netconf_version
         )
-        self._netconf_base_channel_args = NetconfBaseChannelArgs(
-            netconf_version=_preferred_netconf_version
+        _preferred_xml_parser = self._determine_preferred_xml_parser(
+            use_compressed_parser=use_compressed_parser
         )
+        self._netconf_base_channel_args = NetconfBaseChannelArgs(
+            netconf_version=_preferred_netconf_version, xml_parser=_preferred_xml_parser
+        )
+
         self.channel = AsyncNetconfChannel(
             transport=self.transport,
             base_channel_args=self._base_channel_args,

--- a/scrapli_netconf/driver/sync_driver.py
+++ b/scrapli_netconf/driver/sync_driver.py
@@ -38,6 +38,7 @@ class NetconfDriver(Driver, NetconfBaseDriver):
         channel_log: Union[str, bool] = False,
         channel_lock: bool = False,
         preferred_netconf_version: Optional[str] = None,
+        use_compressed_parser: bool = True,
     ) -> None:
         super().__init__(
             host=host,
@@ -68,9 +69,13 @@ class NetconfDriver(Driver, NetconfBaseDriver):
         _preferred_netconf_version = self._determine_preferred_netconf_version(
             preferred_netconf_version=preferred_netconf_version
         )
-        self._netconf_base_channel_args = NetconfBaseChannelArgs(
-            netconf_version=_preferred_netconf_version
+        _preferred_xml_parser = self._determine_preferred_xml_parser(
+            use_compressed_parser=use_compressed_parser
         )
+        self._netconf_base_channel_args = NetconfBaseChannelArgs(
+            netconf_version=_preferred_netconf_version, xml_parser=_preferred_xml_parser
+        )
+
         self.channel = NetconfChannel(
             transport=self.transport,
             base_channel_args=self._base_channel_args,

--- a/scrapli_netconf/transport/plugins/system/transport.py
+++ b/scrapli_netconf/transport/plugins/system/transport.py
@@ -14,6 +14,7 @@ class NetconfSystemTransport(SystemTransport):
         # should also have a similar affect, though this seems simpler.
         self.open_cmd.extend(["-tt"])
         self.open_cmd.extend(["-s", "netconf"])
+        self.logger.debug(f"final open_cmd: {self.open_cmd}")
 
     def open_netconf(self) -> None:
         """

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -12,6 +12,11 @@ NETCONF_1_1_DEVICE_TYPES = ["cisco_iosxe_1_1", "cisco_iosxr_1_1"]
 NETCONF_ALL_VERSIONS_DEVICE_TYPES = NETCONF_1_0_DEVICE_TYPES + NETCONF_1_1_DEVICE_TYPES
 
 
+@pytest.fixture(scope="session", params=(True, False), ids=("compressed", "uncompressed"))
+def use_compressed_parser(request):
+    yield request.param
+
+
 @pytest.fixture(
     scope="session",
     params=NETCONF_1_0_DEVICE_TYPES,
@@ -109,12 +114,12 @@ async def async_conn_1_1(device_type_1_1, auth_type):
 
 
 @pytest.fixture(scope="function")
-def sync_conn(device_type, auth_type, transport):
+def sync_conn(device_type, auth_type, transport, use_compressed_parser):
     device = DEVICES[device_type].copy()
     if auth_type == "key":
         device.pop("auth_password")
         device["auth_private_key"] = PRIVATE_KEY
-    conn = NetconfDriver(**device, transport=transport)
+    conn = NetconfDriver(**device, transport=transport, use_compressed_parser=use_compressed_parser)
     yield conn, device_type
     if conn.isalive():
         conn.close()

--- a/tests/unit/driver/test_base_driver.py
+++ b/tests/unit/driver/test_base_driver.py
@@ -2,7 +2,7 @@ import pytest
 from lxml import etree
 
 from scrapli.exceptions import ScrapliTypeError, ScrapliValueError
-from scrapli_netconf.constants import NetconfClientCapabilities, NetconfVersion
+from scrapli_netconf.constants import NetconfClientCapabilities, NetconfVersion, XmlParserVersion
 from scrapli_netconf.exceptions import CapabilityNotSupported
 from scrapli_netconf.response import NetconfResponse
 
@@ -88,6 +88,25 @@ def test_determine_preferred_netconf_version(dummy_conn, test_data):
 def test_determine_preferred_netconf_version_exception(dummy_conn):
     with pytest.raises(ScrapliValueError):
         dummy_conn._determine_preferred_netconf_version(preferred_netconf_version="blah")
+
+
+@pytest.mark.parametrize(
+    "test_data",
+    (
+        (True, XmlParserVersion.COMPRESSED_PARSER),
+        (False, XmlParserVersion.STANDARD_PARSER),
+    ),
+    ids=(
+        "compressed",
+        "standard",
+    ),
+)
+def test_determine_preferred_xml_parser(dummy_conn, test_data):
+    use_compressed_parser, preferred_parser_output = test_data
+    assert (
+        dummy_conn._determine_preferred_xml_parser(use_compressed_parser=use_compressed_parser)
+        == preferred_parser_output
+    )
 
 
 def test_build_readable_datastores(dummy_conn, parsed_server_capabilities_1_1):


### PR DESCRIPTION
tl;dr nxos at the least has a limitation of 4096 chars that it will accept on a single line -- as we were previously removing all whitespace from the xml payloads large edit configs (or whatever) would end up being way too long and nxos would just seize up and drop the connection eventually. this adds the `use_compressed_payload` option to the netconf driver constructor which will default to true (squished payloads) but let you send false to send pretty printed/uncompressed payloads.

ps. compressed is maybe the wrong word but it'll have to do :) 