### PR TITLE
Added commit confirmed functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 	python -m mypy --strict scrapli_netconf/
 
 darglint:
-	find scrapli_netconf -type f \( -iname "*.py"\ ) | xargs darglint -x
+	find scrapli_netconf -type f \( -iname "*.py" \) | xargs darglint -x
 
 test:
 	python -m pytest \

--- a/examples/basic_usage/basic_usage_iosxr_commit_confirm.py
+++ b/examples/basic_usage/basic_usage_iosxr_commit_confirm.py
@@ -1,4 +1,6 @@
 """
+basic_usage_iosxr_commit_confirm
+
 Script to verify commit confirm functionality using Cisco always on IOSXR
 sandbox device.
 
@@ -7,30 +9,36 @@ Sample terminal output:
 # --------------------------------------------------
 # Test commit confirmed within same session
 # --------------------------------------------------
-    
+
 IOSXR OPEN
-IOSXR LOCK:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+IOSXR LOCK:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
   <ok/>
 </rpc-reply>
 
-IOSXR EDIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+IOSXR EDIT:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
   <ok/>
 </rpc-reply>
 
-IOSXR COMMIT CONFIRMED:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+IOSXR COMMIT CONFIRMED:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
   <ok/>
 </rpc-reply>
 
-IOSXR COMMIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+IOSXR COMMIT:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
   <ok/>
 </rpc-reply>
 
-IOSXR UNLOCK:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="105">
+IOSXR UNLOCK:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="105">
   <ok/>
 </rpc-reply>
 
 IOSXR CHECK description is 'Configured by scrapli-netconf, random int - 7570'
-IOSXR INTERFACE CONFIG <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="106">
+IOSXR INTERFACE CONFIG
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="106">
   <data>
     <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
       <interface-configuration>
@@ -46,27 +54,31 @@ IOSXR INTERFACE CONFIG <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0
 IOSXR CLOSED
 
 # --------------------------------------------------
-# Test commit confirmed within another session 
+# Test commit confirmed within another session
 # using persist-id
 # --------------------------------------------------
-    
+
 IOSXR OPEN
-IOSXR EDIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+IOSXR EDIT:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
   <ok/>
 </rpc-reply>
 
-IOSXR COMMIT CONFIRMED WITH PERSIST:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+IOSXR COMMIT CONFIRMED WITH PERSIST:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
   <ok/>
 </rpc-reply>
 
 IOSXR CLOSED
 IOSXR OPEN AGAIN
-IOSXR COMMIT PERSIST-ID:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+IOSXR COMMIT PERSIST-ID:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
   <ok/>
 </rpc-reply>
 
 IOSXR CHECK description is 'Configured by scrapli-netconf, random int - 5811'
-IOSXR INTERFACE CONFIG <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+IOSXR INTERFACE CONFIG
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
   <data>
     <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
       <interface-configuration>
@@ -84,18 +96,21 @@ IOSXR CLOSED
 # --------------------------------------------------
 # Test commit confirmed with timeout
 # --------------------------------------------------
-    
+
 IOSXR OPEN
-IOSXR EDIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+IOSXR EDIT:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
   <ok/>
 </rpc-reply>
 
-IOSXR COMMIT CONFIRMED TIMEOUT 10s:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+IOSXR COMMIT CONFIRMED TIMEOUT 10s:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
   <ok/>
 </rpc-reply>
 
 IOSXR CHECK description is 'Configured by scrapli-netconf, random int - 5644'
-IOSXR INTERFACE CONFIG:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="103">
+IOSXR INTERFACE CONFIG:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="103">
   <data>
     <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
       <interface-configuration>
@@ -112,7 +127,8 @@ IOSXR CLOSED
 IOSXR sleeping 15 seconds for commit to timeout
 IOSXR OPEN AGAIN
 IOSXR CHECK description is not 'Configured by scrapli-netconf, random int - 5644'
-IOSXR INTERFACE CONFIG after timeout:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+IOSXR INTERFACE CONFIG after timeout:
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
   <data>
     <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
       <interface-configuration>
@@ -127,9 +143,10 @@ IOSXR INTERFACE CONFIG after timeout:  <rpc-reply xmlns="urn:ietf:params:xml:ns:
 
 IOSXR CLOSED
 """
-from scrapli_netconf.driver import NetconfDriver
 import random
 import time
+
+from scrapli_netconf.driver import NetconfDriver
 
 iosxr1 = {
     "host": "sandbox-iosxr-1.cisco.com",
@@ -172,9 +189,7 @@ def test_iosxr_commit_confirmed_in_same_session():
 # --------------------------------------------------
     """
     )
-    description = "Configured by scrapli-netconf, random int - {}".format(
-        random.randrange(1, 10000)
-    )
+    description = f"Configured by scrapli-netconf, random int - {random.randrange(1, 10000)}"
     iosxr1_conn = NetconfDriver(**iosxr1)
     iosxr1_conn.open()
     print("IOSXR OPEN")
@@ -196,7 +211,7 @@ def test_iosxr_commit_confirmed_in_same_session():
     result = iosxr1_conn.unlock(target="candidate")
     print("IOSXR UNLOCK: ", result.result)
 
-    print("IOSXR CHECK description is '{}'".format(description))
+    print(f"IOSXR CHECK description is '{description}'")
     result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
     print("IOSXR INTERFACE CONFIG", result.result)
 
@@ -208,14 +223,12 @@ def test_iosxr_commit_confirmed_in_another_session():
     print(
         """
 # --------------------------------------------------
-# Test commit confirmed within another session 
+# Test commit confirmed within another session
 # using persist-id
 # --------------------------------------------------
     """
     )
-    description = "Configured by scrapli-netconf, random int - {}".format(
-        random.randrange(1, 10000)
-    )
+    description = f"Configured by scrapli-netconf, random int - {random.randrange(1, 10000)}"
     iosxr1_conn = NetconfDriver(**iosxr1)
     iosxr1_conn.open()
     print("IOSXR OPEN")
@@ -238,7 +251,7 @@ def test_iosxr_commit_confirmed_in_another_session():
     iosxr1_conn.commit(persist_id="foobar1234")
     print("IOSXR COMMIT PERSIST-ID: ", result.result)
 
-    print("IOSXR CHECK description is '{}'".format(description))
+    print(f"IOSXR CHECK description is '{description}'")
     result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
     print("IOSXR INTERFACE CONFIG", result.result)
 
@@ -254,9 +267,7 @@ def test_iosxr_commit_confirmed_timeout():
 # --------------------------------------------------
     """
     )
-    description = "Configured by scrapli-netconf, random int - {}".format(
-        random.randrange(1, 10000)
-    )
+    description = f"Configured by scrapli-netconf, random int - {random.randrange(1, 10000)}"
     iosxr1_conn = NetconfDriver(**iosxr1)
     iosxr1_conn.open()
     print("IOSXR OPEN")
@@ -269,7 +280,7 @@ def test_iosxr_commit_confirmed_timeout():
     iosxr1_conn.commit(confirmed=True, timeout=10)
     print("IOSXR COMMIT CONFIRMED TIMEOUT 10s: ", result.result)
 
-    print("IOSXR CHECK description is '{}'".format(description))
+    print(f"IOSXR CHECK description is '{description}'")
     result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
     print("IOSXR INTERFACE CONFIG: ", result.result)
 
@@ -283,7 +294,7 @@ def test_iosxr_commit_confirmed_timeout():
     iosxr1_conn.open()
     print("IOSXR OPEN AGAIN")
 
-    print("IOSXR CHECK description is not '{}'".format(description))
+    print(f"IOSXR CHECK description is not '{description}'")
     result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
     print("IOSXR INTERFACE CONFIG after timeout: ", result.result)
 
@@ -291,6 +302,12 @@ def test_iosxr_commit_confirmed_timeout():
     print("IOSXR CLOSED")
 
 
-test_iosxr_commit_confirmed_in_same_session()
-test_iosxr_commit_confirmed_in_another_session()
-test_iosxr_commit_confirmed_timeout()
+def main():
+    """Run commit confirmed examples"""
+    test_iosxr_commit_confirmed_in_same_session()
+    test_iosxr_commit_confirmed_in_another_session()
+    test_iosxr_commit_confirmed_timeout()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic_usage/basic_usage_iosxr_commit_confirm.py
+++ b/examples/basic_usage/basic_usage_iosxr_commit_confirm.py
@@ -1,0 +1,296 @@
+"""
+Script to verify commit confirm functionality using Cisco always on IOSXR
+sandbox device.
+
+Sample terminal output:
+
+# --------------------------------------------------
+# Test commit confirmed within same session
+# --------------------------------------------------
+    
+IOSXR OPEN
+IOSXR LOCK:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+  <ok/>
+</rpc-reply>
+
+IOSXR EDIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+  <ok/>
+</rpc-reply>
+
+IOSXR COMMIT CONFIRMED:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+  <ok/>
+</rpc-reply>
+
+IOSXR COMMIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+  <ok/>
+</rpc-reply>
+
+IOSXR UNLOCK:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="105">
+  <ok/>
+</rpc-reply>
+
+IOSXR CHECK description is 'Configured by scrapli-netconf, random int - 7570'
+IOSXR INTERFACE CONFIG <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="106">
+  <data>
+    <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+      <interface-configuration>
+        <active>act</active>
+        <interface-name>Loopback111</interface-name>
+        <interface-virtual/>
+        <description>Configured by scrapli-netconf, random int - 7570</description>
+      </interface-configuration>
+    </interface-configurations>
+  </data>
+</rpc-reply>
+
+IOSXR CLOSED
+
+# --------------------------------------------------
+# Test commit confirmed within another session 
+# using persist-id
+# --------------------------------------------------
+    
+IOSXR OPEN
+IOSXR EDIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+  <ok/>
+</rpc-reply>
+
+IOSXR COMMIT CONFIRMED WITH PERSIST:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+  <ok/>
+</rpc-reply>
+
+IOSXR CLOSED
+IOSXR OPEN AGAIN
+IOSXR COMMIT PERSIST-ID:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+  <ok/>
+</rpc-reply>
+
+IOSXR CHECK description is 'Configured by scrapli-netconf, random int - 5811'
+IOSXR INTERFACE CONFIG <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102">
+  <data>
+    <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+      <interface-configuration>
+        <active>act</active>
+        <interface-name>Loopback111</interface-name>
+        <interface-virtual/>
+        <description>Configured by scrapli-netconf, random int - 5811</description>
+      </interface-configuration>
+    </interface-configurations>
+  </data>
+</rpc-reply>
+
+IOSXR CLOSED
+
+# --------------------------------------------------
+# Test commit confirmed with timeout
+# --------------------------------------------------
+    
+IOSXR OPEN
+IOSXR EDIT:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+  <ok/>
+</rpc-reply>
+
+IOSXR COMMIT CONFIRMED TIMEOUT 10s:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+  <ok/>
+</rpc-reply>
+
+IOSXR CHECK description is 'Configured by scrapli-netconf, random int - 5644'
+IOSXR INTERFACE CONFIG:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="103">
+  <data>
+    <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+      <interface-configuration>
+        <active>act</active>
+        <interface-name>Loopback111</interface-name>
+        <interface-virtual/>
+        <description>Configured by scrapli-netconf, random int - 5644</description>
+      </interface-configuration>
+    </interface-configurations>
+  </data>
+</rpc-reply>
+
+IOSXR CLOSED
+IOSXR sleeping 15 seconds for commit to timeout
+IOSXR OPEN AGAIN
+IOSXR CHECK description is not 'Configured by scrapli-netconf, random int - 5644'
+IOSXR INTERFACE CONFIG after timeout:  <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+  <data>
+    <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+      <interface-configuration>
+        <active>act</active>
+        <interface-name>Loopback111</interface-name>
+        <interface-virtual/>
+        <description>Configured by scrapli-netconf, random int - 5811</description>
+      </interface-configuration>
+    </interface-configurations>
+  </data>
+</rpc-reply>
+
+IOSXR CLOSED
+"""
+from scrapli_netconf.driver import NetconfDriver
+import random
+import time
+
+iosxr1 = {
+    "host": "sandbox-iosxr-1.cisco.com",
+    "auth_username": "admin",
+    "auth_password": "C1sco12345",
+    "port": 830,
+    "auth_strict_key": False,
+}
+
+IOS_XR_EDIT_CONFIG = """
+<config>
+  <interfaces xmlns="http://openconfig.net/yang/interfaces">
+   <interface>
+    <name>Loopback111</name>
+    <config>
+     <name>Loopback111</name>
+     <type xmlns:idx="urn:ietf:params:xml:ns:yang:iana-if-type">idx:softwareLoopback</type>
+     <enabled>true</enabled>
+     <description>{}</description>
+    </config>
+   </interface>
+  </interfaces>
+</config>
+"""
+
+IOS_XR_FILTER = """
+<interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg">
+    <interface-configuration>
+        <interface-name>Loopback111</interface-name>
+    </interface-configuration>
+</interface-configurations>
+"""
+
+
+def test_iosxr_commit_confirmed_in_same_session():
+    print(
+        """
+# --------------------------------------------------
+# Test commit confirmed within same session
+# --------------------------------------------------
+    """
+    )
+    description = "Configured by scrapli-netconf, random int - {}".format(
+        random.randrange(1, 10000)
+    )
+    iosxr1_conn = NetconfDriver(**iosxr1)
+    iosxr1_conn.open()
+    print("IOSXR OPEN")
+
+    result = iosxr1_conn.lock(target="candidate")
+    print("IOSXR LOCK: ", result.result)
+
+    result = iosxr1_conn.edit_config(
+        config=IOS_XR_EDIT_CONFIG.format(description), target="candidate"
+    )
+    print("IOSXR EDIT: ", result.result)
+
+    iosxr1_conn.commit(confirmed=True)
+    print("IOSXR COMMIT CONFIRMED: ", result.result)
+
+    iosxr1_conn.commit()
+    print("IOSXR COMMIT: ", result.result)
+
+    result = iosxr1_conn.unlock(target="candidate")
+    print("IOSXR UNLOCK: ", result.result)
+
+    print("IOSXR CHECK description is '{}'".format(description))
+    result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
+    print("IOSXR INTERFACE CONFIG", result.result)
+
+    iosxr1_conn.close()
+    print("IOSXR CLOSED")
+
+
+def test_iosxr_commit_confirmed_in_another_session():
+    print(
+        """
+# --------------------------------------------------
+# Test commit confirmed within another session 
+# using persist-id
+# --------------------------------------------------
+    """
+    )
+    description = "Configured by scrapli-netconf, random int - {}".format(
+        random.randrange(1, 10000)
+    )
+    iosxr1_conn = NetconfDriver(**iosxr1)
+    iosxr1_conn.open()
+    print("IOSXR OPEN")
+
+    result = iosxr1_conn.edit_config(
+        config=IOS_XR_EDIT_CONFIG.format(description), target="candidate"
+    )
+    print("IOSXR EDIT: ", result.result)
+
+    iosxr1_conn.commit(confirmed=True, persist="foobar1234")
+    print("IOSXR COMMIT CONFIRMED WITH PERSIST: ", result.result)
+
+    iosxr1_conn.close()
+    print("IOSXR CLOSED")
+
+    iosxr1_conn = NetconfDriver(**iosxr1)
+    iosxr1_conn.open()
+    print("IOSXR OPEN AGAIN")
+
+    iosxr1_conn.commit(persist_id="foobar1234")
+    print("IOSXR COMMIT PERSIST-ID: ", result.result)
+
+    print("IOSXR CHECK description is '{}'".format(description))
+    result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
+    print("IOSXR INTERFACE CONFIG", result.result)
+
+    iosxr1_conn.close()
+    print("IOSXR CLOSED")
+
+
+def test_iosxr_commit_confirmed_timeout():
+    print(
+        """
+# --------------------------------------------------
+# Test commit confirmed with timeout
+# --------------------------------------------------
+    """
+    )
+    description = "Configured by scrapli-netconf, random int - {}".format(
+        random.randrange(1, 10000)
+    )
+    iosxr1_conn = NetconfDriver(**iosxr1)
+    iosxr1_conn.open()
+    print("IOSXR OPEN")
+
+    result = iosxr1_conn.edit_config(
+        config=IOS_XR_EDIT_CONFIG.format(description), target="candidate"
+    )
+    print("IOSXR EDIT: ", result.result)
+
+    iosxr1_conn.commit(confirmed=True, timeout=10)
+    print("IOSXR COMMIT CONFIRMED TIMEOUT 10s: ", result.result)
+
+    print("IOSXR CHECK description is '{}'".format(description))
+    result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
+    print("IOSXR INTERFACE CONFIG: ", result.result)
+
+    iosxr1_conn.close()
+    print("IOSXR CLOSED")
+
+    print("IOSXR sleeping 15 seconds for commit to timeout")
+    time.sleep(15)
+
+    iosxr1_conn = NetconfDriver(**iosxr1)
+    iosxr1_conn.open()
+    print("IOSXR OPEN AGAIN")
+
+    print("IOSXR CHECK description is not '{}'".format(description))
+    result = iosxr1_conn.get_config(source="running", filter_=IOS_XR_FILTER)
+    print("IOSXR INTERFACE CONFIG after timeout: ", result.result)
+
+    iosxr1_conn.close()
+    print("IOSXR CLOSED")
+
+
+test_iosxr_commit_confirmed_in_same_session()
+test_iosxr_commit_confirmed_in_another_session()
+test_iosxr_commit_confirmed_timeout()

--- a/scrapli_netconf/driver/async_driver.py
+++ b/scrapli_netconf/driver/async_driver.py
@@ -210,8 +210,8 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
         self,
         confirmed: bool = False,
         timeout: Optional[int] = None,
-        persist: Optional[int] = None,
-        persist_id: Optional[int] = None,
+        persist: Optional[Union[int, str]] = None,
+        persist_id: Optional[Union[int, str]] = None,
     ) -> NetconfResponse:
         """
         Netconf commit config operation

--- a/scrapli_netconf/driver/async_driver.py
+++ b/scrapli_netconf/driver/async_driver.py
@@ -206,12 +206,21 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
         response.record_response(raw_response)
         return response
 
-    async def commit(self) -> NetconfResponse:
+    async def commit(
+        self,
+        confirmed: bool = False,
+        timeout: int = None,
+        persist: int = None,
+        persist_id: int = None,
+    ) -> NetconfResponse:
         """
         Netconf commit config operation
 
         Args:
-            N/A
+            confirmed: whether this is a confirmed commit
+            timeout: specifies the confirm timeout in seconds
+            persist: make the confirmed commit survive a session termination, and set a token on the ongoing confirmed commit
+            persist_id: value must be equal to the value given in the <persist> parameter to the original <commit> operation.
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object
@@ -220,7 +229,12 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
             N/A
 
         """
-        response = self._pre_commit()
+        response = self._pre_commit(
+            confirmed=confirmed,
+            timeout=timeout,
+            persist=persist,
+            persist_id=persist_id,
+        )
         raw_response = await self.channel.send_input_netconf(response.channel_input)
         response.record_response(raw_response)
         return response

--- a/scrapli_netconf/driver/async_driver.py
+++ b/scrapli_netconf/driver/async_driver.py
@@ -209,9 +209,9 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
     async def commit(
         self,
         confirmed: bool = False,
-        timeout: int = None,
-        persist: int = None,
-        persist_id: int = None,
+        timeout: Optional[int] = None,
+        persist: Optional[int] = None,
+        persist_id: Optional[int] = None,
     ) -> NetconfResponse:
         """
         Netconf commit config operation
@@ -219,8 +219,10 @@ class AsyncNetconfDriver(AsyncDriver, NetconfBaseDriver):
         Args:
             confirmed: whether this is a confirmed commit
             timeout: specifies the confirm timeout in seconds
-            persist: make the confirmed commit survive a session termination, and set a token on the ongoing confirmed commit
-            persist_id: value must be equal to the value given in the <persist> parameter to the original <commit> operation.
+            persist: make the confirmed commit survive a session termination, and set a token on
+                the ongoing confirmed commit
+            persist_id: value must be equal to the value given in the <persist> parameter to the
+                original <commit> operation.
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object

--- a/scrapli_netconf/driver/base_driver.py
+++ b/scrapli_netconf/driver/base_driver.py
@@ -35,6 +35,10 @@ class NetconfBaseOperations(Enum):
         "<copy-config><target><{target}/></target><source><{source}/></source></copy-config>"
     )
     COMMIT = "<commit/>"
+    COMMIT_CONFIRMED = "<confirmed/>"
+    COMMIT_CONFIRMED_TIMEOUT = "<confirm-timeout>{timeout}</confirm-timeout>"
+    COMMIT_CONFIRMED_PERSIST = "<persist>{persist}</persist>"
+    COMMIT_PERSIST_ID = "<persist-id>{persist_id}</persist-id>"
     DISCARD = "<discard-changes/>"
     LOCK = "<lock><target><{target}/></target></lock>"
     UNLOCK = "<unlock><target><{target}/></target></unlock>"
@@ -768,12 +772,21 @@ class NetconfBaseDriver(BaseDriver):
         )
         return response
 
-    def _pre_commit(self) -> NetconfResponse:
+    def _pre_commit(
+        self,
+        confirmed: bool = False,
+        timeout: int = None,
+        persist: int = None,
+        persist_id: int = None,
+    ) -> NetconfResponse:
         """
         Handle pre "commit" tasks for consistency between sync/async versions
 
         Args:
-            N/A
+            confirmed: whether this is a confirmed commit
+            timeout: specifies the confirm timeout in seconds
+            persist: make the confirmed commit survive a session termination, and set a token on the ongoing confirmed commit
+            persist_id: value must be equal to the value given in the <persist> parameter to the original <commit> operation.
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object containing all the necessary
@@ -788,6 +801,64 @@ class NetconfBaseDriver(BaseDriver):
         xml_commit_element = etree.fromstring(
             NetconfBaseOperations.COMMIT.value, parser=self.xml_parser
         )
+
+        if persist and persist_id:
+            raise ScrapliValueError(
+                "Invalid combination - 'persist' cannot be present with 'persist-id'"
+            )
+        if confirmed and persist_id:
+            raise ScrapliValueError(
+                "Invalid combination - 'confirmed' cannot be present with 'persist-id'"
+            )
+
+        if confirmed:
+            if not any(
+                cap in self.server_capabilities
+                for cap in (
+                    "urn:ietf:params:netconf:capability:confirmed-commit:1.0",
+                    "urn:ietf:params:netconf:capability:confirmed-commit:1.1",
+                )
+            ):
+                msg = "confirmed-commit requested, but is not supported by the server"
+                self.logger.exception(msg)
+                raise CapabilityNotSupported(msg)
+
+            xml_confirmed_element = etree.fromstring(
+                NetconfBaseOperations.COMMIT_CONFIRMED.value, parser=self.xml_parser
+            )
+            xml_commit_element.append(xml_confirmed_element)
+
+            if timeout is not None:
+                xml_timeout_element = etree.fromstring(
+                    NetconfBaseOperations.COMMIT_CONFIRMED_TIMEOUT.value.format(timeout=timeout),
+                    parser=self.xml_parser,
+                )
+                xml_commit_element.append(xml_timeout_element)
+
+            if persist is not None:
+                xml_persist_element = etree.fromstring(
+                    NetconfBaseOperations.COMMIT_CONFIRMED_PERSIST.value.format(persist=persist),
+                    parser=self.xml_parser,
+                )
+                xml_commit_element.append(xml_persist_element)
+
+        if persist_id is not None:
+            if not any(
+                cap in self.server_capabilities
+                for cap in (
+                    "urn:ietf:params:netconf:capability:confirmed-commit:1.0",
+                    "urn:ietf:params:netconf:capability:confirmed-commit:1.1",
+                )
+            ):
+                msg = "commit with 'persist-id' requested, but 'confirmed-commit' is not supported by the server"
+                self.logger.exception(msg)
+                raise CapabilityNotSupported(msg)
+            xml_persist_id_element = etree.fromstring(
+                NetconfBaseOperations.COMMIT_PERSIST_ID.value.format(persist_id=persist_id),
+                parser=self.xml_parser,
+            )
+            xml_commit_element.append(xml_persist_id_element)
+
         xml_request.insert(0, xml_commit_element)
 
         channel_input = self._finalize_channel_input(xml_request=xml_request)

--- a/scrapli_netconf/driver/base_driver.py
+++ b/scrapli_netconf/driver/base_driver.py
@@ -775,9 +775,9 @@ class NetconfBaseDriver(BaseDriver):
     def _pre_commit(
         self,
         confirmed: bool = False,
-        timeout: int = None,
-        persist: int = None,
-        persist_id: int = None,
+        timeout: Optional[int] = None,
+        persist: Optional[int] = None,
+        persist_id: Optional[int] = None,
     ) -> NetconfResponse:
         """
         Handle pre "commit" tasks for consistency between sync/async versions
@@ -785,8 +785,10 @@ class NetconfBaseDriver(BaseDriver):
         Args:
             confirmed: whether this is a confirmed commit
             timeout: specifies the confirm timeout in seconds
-            persist: make the confirmed commit survive a session termination, and set a token on the ongoing confirmed commit
-            persist_id: value must be equal to the value given in the <persist> parameter to the original <commit> operation.
+            persist: make the confirmed commit survive a session termination, and set a token on
+                the ongoing confirmed commit
+            persist_id: value must be equal to the value given in the <persist> parameter to the
+                original <commit> operation.
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object containing all the necessary
@@ -850,7 +852,10 @@ class NetconfBaseDriver(BaseDriver):
                     "urn:ietf:params:netconf:capability:confirmed-commit:1.1",
                 )
             ):
-                msg = "commit with 'persist-id' requested, but 'confirmed-commit' is not supported by the server"
+                msg = (
+                    "commit with 'persist-id' requested, but 'confirmed-commit' is not supported "
+                    "by the server"
+                )
                 self.logger.exception(msg)
                 raise CapabilityNotSupported(msg)
             xml_persist_id_element = etree.fromstring(

--- a/scrapli_netconf/driver/base_driver.py
+++ b/scrapli_netconf/driver/base_driver.py
@@ -776,8 +776,8 @@ class NetconfBaseDriver(BaseDriver):
         self,
         confirmed: bool = False,
         timeout: Optional[int] = None,
-        persist: Optional[int] = None,
-        persist_id: Optional[int] = None,
+        persist: Optional[Union[int, str]] = None,
+        persist_id: Optional[Union[int, str]] = None,
     ) -> NetconfResponse:
         """
         Handle pre "commit" tasks for consistency between sync/async versions

--- a/scrapli_netconf/driver/sync_driver.py
+++ b/scrapli_netconf/driver/sync_driver.py
@@ -216,12 +216,21 @@ class NetconfDriver(Driver, NetconfBaseDriver):
         response.record_response(raw_response)
         return response
 
-    def commit(self) -> NetconfResponse:
+    def commit(
+        self,
+        confirmed: bool = False,
+        timeout: int = None,
+        persist: int = None,
+        persist_id: int = None,
+    ) -> NetconfResponse:
         """
         Netconf commit config operation
 
         Args:
-            N/A
+            confirmed: whether this is a confirmed commit
+            timeout: specifies the confirm timeout in seconds
+            persist: make the confirmed commit survive a session termination, and set a token on the ongoing confirmed commit
+            persist_id: value must be equal to the value given in the <persist> parameter to the original <commit> operation.
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object
@@ -230,7 +239,12 @@ class NetconfDriver(Driver, NetconfBaseDriver):
             N/A
 
         """
-        response = self._pre_commit()
+        response = self._pre_commit(
+            confirmed=confirmed,
+            timeout=timeout,
+            persist=persist,
+            persist_id=persist_id,
+        )
         raw_response = self.channel.send_input_netconf(response.channel_input)
         response.record_response(raw_response)
         return response

--- a/scrapli_netconf/driver/sync_driver.py
+++ b/scrapli_netconf/driver/sync_driver.py
@@ -219,9 +219,9 @@ class NetconfDriver(Driver, NetconfBaseDriver):
     def commit(
         self,
         confirmed: bool = False,
-        timeout: int = None,
-        persist: int = None,
-        persist_id: int = None,
+        timeout: Optional[int] = None,
+        persist: Optional[int] = None,
+        persist_id: Optional[int] = None,
     ) -> NetconfResponse:
         """
         Netconf commit config operation
@@ -229,8 +229,10 @@ class NetconfDriver(Driver, NetconfBaseDriver):
         Args:
             confirmed: whether this is a confirmed commit
             timeout: specifies the confirm timeout in seconds
-            persist: make the confirmed commit survive a session termination, and set a token on the ongoing confirmed commit
-            persist_id: value must be equal to the value given in the <persist> parameter to the original <commit> operation.
+            persist: make the confirmed commit survive a session termination, and set a token on
+                the ongoing confirmed commit
+            persist_id: value must be equal to the value given in the <persist> parameter to the
+                original <commit> operation.
 
         Returns:
             NetconfResponse: scrapli_netconf NetconfResponse object

--- a/scrapli_netconf/driver/sync_driver.py
+++ b/scrapli_netconf/driver/sync_driver.py
@@ -220,8 +220,8 @@ class NetconfDriver(Driver, NetconfBaseDriver):
         self,
         confirmed: bool = False,
         timeout: Optional[int] = None,
-        persist: Optional[int] = None,
-        persist_id: Optional[int] = None,
+        persist: Optional[Union[int, str]] = None,
+        persist_id: Optional[Union[int, str]] = None,
     ) -> NetconfResponse:
         """
         Netconf commit config operation

--- a/tests/unit/driver/test_base_driver.py
+++ b/tests/unit/driver/test_base_driver.py
@@ -395,6 +395,173 @@ def test_pre_commit(dummy_conn, capabilities):
 @pytest.mark.parametrize(
     "capabilities",
     [
+        (NetconfVersion.VERSION_1_0, ["urn:ietf:params:netconf:capability:confirmed-commit:1.0"]),
+        (NetconfVersion.VERSION_1_1, ["urn:ietf:params:netconf:capability:confirmed-commit:1.1"]),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_confirmed(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for expected XML payload
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    response = dummy_conn._pre_commit(confirmed=True)
+    assert "<commit><confirmed/></commit>" in response.channel_input
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (NetconfVersion.VERSION_1_0, ["urn:ietf:params:netconf:capability:confirmed-commit:1.0"]),
+        (NetconfVersion.VERSION_1_1, ["urn:ietf:params:netconf:capability:confirmed-commit:1.1"]),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_confirmed_timeout(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for expected XML payload
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    response = dummy_conn._pre_commit(confirmed=True, timeout=60)
+    assert "<confirmed/>" in response.channel_input
+    assert "<confirm-timeout>60</confirm-timeout>" in response.channel_input
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (NetconfVersion.VERSION_1_0, ["urn:ietf:params:netconf:capability:confirmed-commit:1.0"]),
+        (NetconfVersion.VERSION_1_1, ["urn:ietf:params:netconf:capability:confirmed-commit:1.1"]),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_confirmed_timeout_persist(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for expected XML payload
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    response = dummy_conn._pre_commit(confirmed=True, timeout=60, persist="foobar1234")
+    assert "<confirmed/>" in response.channel_input
+    assert "<confirm-timeout>60</confirm-timeout>" in response.channel_input
+    assert "<persist>foobar1234</persist>" in response.channel_input
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (NetconfVersion.VERSION_1_0, ["urn:ietf:params:netconf:capability:confirmed-commit:1.0"]),
+        (NetconfVersion.VERSION_1_1, ["urn:ietf:params:netconf:capability:confirmed-commit:1.1"]),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_with_persist_id(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for expected XML payload
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    response = dummy_conn._pre_commit(persist_id="foobar1234")
+    assert "<persist-id>foobar1234</persist-id>" in response.channel_input
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (NetconfVersion.VERSION_1_0, ["urn:ietf:params:netconf:capability:confirmed-commit:1.0"]),
+        (NetconfVersion.VERSION_1_1, ["urn:ietf:params:netconf:capability:confirmed-commit:1.1"]),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_fail_persist_id_with_confirmed(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for expected XML payload
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    with pytest.raises(ScrapliValueError) as e:
+        _ = dummy_conn._pre_commit(confirmed=True, persist_id="foobar1234")
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (NetconfVersion.VERSION_1_0, ["urn:ietf:params:netconf:capability:confirmed-commit:1.0"]),
+        (NetconfVersion.VERSION_1_1, ["urn:ietf:params:netconf:capability:confirmed-commit:1.1"]),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_fail_persist_id_with_persist(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for expected XML payload
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    with pytest.raises(ScrapliValueError) as e:
+        _ = dummy_conn._pre_commit(persist="foobar1234", persist_id="foobar1234")
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (
+            NetconfVersion.VERSION_1_0,
+            ["urn:ietf:params:netconf:capability:confirmed-foo-commit:1.0"],
+        ),
+        (
+            NetconfVersion.VERSION_1_1,
+            ["urn:ietf:params:netconf:capability:confirmed-foo-commit:1.1"],
+        ),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_fail_confirmed_unsupported_capability(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for required capabilities
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    with pytest.raises(CapabilityNotSupported) as e:
+        _ = dummy_conn._pre_commit(confirmed=True)
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        (
+            NetconfVersion.VERSION_1_0,
+            ["urn:ietf:params:netconf:capability:confirmed-foo-commit:1.0"],
+        ),
+        (
+            NetconfVersion.VERSION_1_1,
+            ["urn:ietf:params:netconf:capability:confirmed-foo-commit:1.1"],
+        ),
+    ],
+    ids=["1.0", "1.1"],
+)
+def test_pre_commit_fail_persist_id_unsupported_capability(dummy_conn, capabilities):
+    """
+    Refer to https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.5.1
+    for required capabilities
+    """
+    dummy_conn.netconf_version = capabilities[0]
+    dummy_conn.server_capabilities = capabilities[1]
+    with pytest.raises(CapabilityNotSupported) as e:
+        _ = dummy_conn._pre_commit(persist_id="foobar1234")
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
         (NetconfVersion.VERSION_1_0, DISCARD_CHANNEL_INPUT_1_0),
         (NetconfVersion.VERSION_1_1, DISCARD_CHANNEL_INPUT_1_1),
     ],


### PR DESCRIPTION
# Description

Added support for `confirmed`, `persist `and `persist_id` parameters to commit RPC call together with test and sample usage using IOSXR always on sandbox.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`test_base_driver.py` updated with these tests:
```
unit/driver/test_base_driver.py::test_pre_commit_confirmed[1.0] PASSED                                                                                                      [ 61%]
unit/driver/test_base_driver.py::test_pre_commit_confirmed[1.1] PASSED                                                                                                      [ 63%]
unit/driver/test_base_driver.py::test_pre_commit_confirmed_timeout[1.0] PASSED                                                                                              [ 64%]
unit/driver/test_base_driver.py::test_pre_commit_confirmed_timeout[1.1] PASSED                                                                                              [ 65%]
unit/driver/test_base_driver.py::test_pre_commit_confirmed_timeout_persist[1.0] PASSED                                                                                      [ 67%]
unit/driver/test_base_driver.py::test_pre_commit_confirmed_timeout_persist[1.1] PASSED                                                                                      [ 68%]
unit/driver/test_base_driver.py::test_pre_commit_with_persist_id[1.0] PASSED                                                                                                [ 69%]
unit/driver/test_base_driver.py::test_pre_commit_with_persist_id[1.1] PASSED                                                                                                [ 71%]
unit/driver/test_base_driver.py::test_pre_commit_fail_persist_id_with_confirmed[1.0] PASSED                                                                                 [ 72%]
unit/driver/test_base_driver.py::test_pre_commit_fail_persist_id_with_confirmed[1.1] PASSED                                                                                 [ 73%]
unit/driver/test_base_driver.py::test_pre_commit_fail_persist_id_with_persist[1.0] PASSED                                                                                   [ 75%]
unit/driver/test_base_driver.py::test_pre_commit_fail_persist_id_with_persist[1.1] PASSED                                                                                   [ 76%]
unit/driver/test_base_driver.py::test_pre_commit_fail_confirmed_unsupported_capability[1.0] PASSED                                                                          [ 78%]
unit/driver/test_base_driver.py::test_pre_commit_fail_confirmed_unsupported_capability[1.1] PASSED                                                                          [ 79%]
unit/driver/test_base_driver.py::test_pre_commit_fail_persist_id_unsupported_capability[1.0] PASSED                                                                         [ 80%]
unit/driver/test_base_driver.py::test_pre_commit_fail_persist_id_unsupported_capability[1.1] PASSED                                                                         [ 82%]
```

Also added examples/basic_usage/basic_usage_iosxr_commit_confirm.py file with 3 examples demonstrating commit confirmed functionality:

1. test_iosxr_commit_confirmed_in_same_session
2. test_iosxr_commit_confirmed_in_another_session
3. test_iosxr_commit_confirmed_timeout

# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [x] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
