### PR TITLE
Fix scrapli consuming too much input with read()

### DIFF
--- a/scrapli_netconf/channel/base_channel.py
+++ b/scrapli_netconf/channel/base_channel.py
@@ -103,10 +103,15 @@ class BaseNetconfChannel(BaseChannel):
             string=raw_server_capabilities,
             flags=re.I | re.S,
         )
+
         if filtered_raw_server_capabilities is None:
             msg = "failed to parse server capabilities"
             raise CouldNotExchangeCapabilities(msg)
-        server_capabilities_xml = etree.fromstring(filtered_raw_server_capabilities.groups()[0])
+
+        # IOSXR/XR7 7.3.1 returns corrupt '<capabil\n\nity>' property on call-home line
+        my_payload = filtered_raw_server_capabilities.groups()[0].replace(b"\n", b"")
+
+        server_capabilities_xml = etree.fromstring(my_payload)
         for elem in server_capabilities_xml.iter():
             if "capability" not in elem.tag:
                 continue
@@ -149,7 +154,7 @@ class BaseNetconfChannel(BaseChannel):
 
         """
         self.logger.info("sending client capabilities")
-        bytes_client_capabilities: bytes = client_capabilities.value.encode().strip()
+        bytes_client_capabilities: bytes = client_capabilities.value.encode()
         self.logger.debug(f"attempting to send capabilities: {client_capabilities}")
         self.write(client_capabilities.value)
         return bytes_client_capabilities

--- a/tests/unit/channel/test_sync_channel.py
+++ b/tests/unit/channel/test_sync_channel.py
@@ -89,7 +89,7 @@ def test_get_server_capabilities(monkeypatch, dummy_conn):
 
     monkeypatch.setattr("scrapli.transport.plugins.system.transport.SystemTransport.read", _read)
 
-    assert dummy_conn.channel._get_server_capabilities() == b"lasjdfkldsjaflkdjf]]>]]>"
+    assert dummy_conn.channel._get_server_capabilities() == b"lasjdfkldsjaflkdjf"
 
 
 def test_send_client_capabilities():
@@ -98,8 +98,8 @@ def test_send_client_capabilities():
 
 @pytest.mark.parametrize(
     "test_data",
-    ((b"blah", b"blah"), (b"", b""), (b"blah", b"rpc>")),
-    ids=("some_input", "no_input", "rpc_in_output"),
+    ((b"blah", b"blah"), (b"", b"")),
+    ids=("some_input", "no_input"),
 )
 def test_read_until_input(monkeypatch, dummy_conn, test_data):
     channel_input, expected_read_input = test_data
@@ -124,7 +124,7 @@ def test_send_input_netconf(monkeypatch, dummy_conn):
     _read_counter = 0
 
     channel_input = "show version"
-    expected_buf = b"output from show version!\n]]>]]>"
+    expected_buf = b" ##output from show version!\n]]>]]>"
 
     def _read(cls):
         nonlocal _read_counter


### PR DESCRIPTION
# Description

Current implementation always consumes the whole of read(). This could lead to missing data for subsequent calls

We implement the _read_tail buffer that stores the un-parsed data and make it available for the next call

See https://github.com/scrapli/scrapli_netconf/issues/122 for details

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Warning**: **Dependency on https://github.com/carlmontanari/scrapli/pull/255**

# How Has This Been Tested?

Tested on IOS-XR and junos-EVO lab devices.
Ran channel unit-test.


# Checklist:

- [X] My code follows the style guidelines of this project (no GitHub actions compalints! run `make lint` before
 committing!)
- [X] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [X] New and existing unit tests pass locally with my changes
