### PR TITLE
fix: avoid adding break line between each chunk

### DIFF
--- a/scrapli_netconf/response.py
+++ b/scrapli_netconf/response.py
@@ -230,7 +230,7 @@ class NetconfResponse(Response):
             cursor += chunk_size
 
         self.xml_result = etree.fromstring(
-            b"\n".join(
+            b"".join(
                 [
                     # remove the message end characters and xml document header see:
                     # https://github.com/scrapli/scrapli_netconf/issues/1


### PR DESCRIPTION
# Description

The [RFC ](https://www.rfc-editor.org/rfc/rfc6242#section-4.2) do not say that a break line must be add between each chunk. if a xml tag contain a text splitted in multiple chunk, the lib must not add break line for exemple

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manuel test on SROS

